### PR TITLE
spark.__force_clean stops Spark instances in all nodes, not only in the master node

### DIFF
--- a/hadoop_g5k/ecosystem/spark.py
+++ b/hadoop_g5k/ecosystem/spark.py
@@ -287,10 +287,8 @@ class SparkCluster(object):
                                  "cluster.")
 
         # Store reference to Hadoop cluster and check if mandatory
-        if hadoop_cluster:
-            self.hc = hadoop_cluster
-        else:
-            if mode == YARN_MODE:
+        self.hc = hadoop_cluster
+        if mode == YARN_MODE and self.hc == None:
                 logger.error("When using a YARN_MODE mode, a reference to the "
                              "Hadoop cluster should be provided.")
                 raise SparkException("When using a YARN_MODE mode, a reference "
@@ -300,11 +298,21 @@ class SparkCluster(object):
             mode_text = "in standalone mode"
         else:
             mode_text = "on top of YARN"
-        logger.info("Spark cluster created %s in hosts %s."
-                    " It is linked to a Hadoop cluster." if self.hc else "",
-                    mode_text,
-                    ' '.join([style.host(h.address.split('.')[0])
-                              for h in self.hosts]))
+
+        if self.hc != None:
+            cluster_text = " It is linked to a Hadoop cluster."
+        else:
+            cluster_text = ""
+
+        hosts = ' '.join([style.host(h.address.split('.')[0]) for h in self.hosts])
+
+        if self.hc:
+            logger.info("Spark cluster created %s in hosts %s.%s", mode_text,
+                    hosts, cluster_text)
+        else:
+            logger.info("Spark cluster created %s in hosts %s.%s", mode_text,
+                    hosts, cluster_text)
+
 
     def bootstrap(self, tar_file):
 

--- a/hadoop_g5k/ecosystem/spark.py
+++ b/hadoop_g5k/ecosystem/spark.py
@@ -729,7 +729,7 @@ class SparkCluster(object):
 
         force_kill = False
         for h in self.hosts:
-            proc = SshProcess("jps", self.master)
+            proc = SshProcess("jps", h)
             proc.run()
 
             ids_to_kill = []
@@ -743,6 +743,10 @@ class SparkCluster(object):
                 ids_to_kill_str = ""
                 for pid in ids_to_kill:
                     ids_to_kill_str += " " + pid
+
+                logger.warn(
+                    "Killing running Spark processes in host %s" %
+                    style.host(h.address.split('.')[0]))
 
                 proc = SshProcess("kill -9" + ids_to_kill_str, h)
                 proc.run()


### PR DESCRIPTION
In the base code ```spark.__force_clean``` iterates over the list of hosts, nevertheless, only check for Spark process in the master node. With this patch it will check for Spark process in all nodes.