### PR TITLE
g5k api change: smt_site is now nb_cores

### DIFF
--- a/hadoop_g5k/util/g5k.py
+++ b/hadoop_g5k/util/g5k.py
@@ -23,7 +23,7 @@ class G5kHardwareManager(HardwareManager):
 
     def get_memory_and_cores(self, host):
         host_attrs = get_host_attributes(host)
-        cores = host_attrs[u'architecture'][u'smt_size']
+        cores = host_attrs[u'architecture'][u'nb_cores']
         mem = host_attrs[u'main_memory'][u'ram_size'] / (1024 * 1024)
 
         return mem, cores


### PR DESCRIPTION
Hi,
I don't know if you'r still active on grid5000 and on this code. The Grid5000 API recently changed and attribute smt_size is now renamed nb_cores, with a slightly different semantic: now hyperthreading is activated by default on all clusters so if you want the number of "logical" cores on nodes supporting hyperthreading, you need to use nb_threads instead of nb_cores.
In this commit i use nb_cores, as I'm not sure which is more appropriate (nb_cores / nb_threads) in the context of hg5k.
If you're not willing to maintain anymore hg5k, please tell me so that either we find someone interrested in maintening it or we can say that it's not supported anymore.
best!
Matthieu
