### PR TITLE
prevent attributeError exception when 'match' has type 'NoneType'

### DIFF
--- a/hadoop_g5k/util/util.py
+++ b/hadoop_g5k/util/util.py
@@ -71,10 +71,11 @@ def check_java_version(java_major_version, hosts):
 
     for p in tr.processes:
         match = re.match('.*[^.0-9]1\.([0-9]+).[0-9].*', p.stdout)
-        version = int(match.group(1))
-        if java_major_version > version:
-            msg = "Java 1.%d+ required" % java_major_version
-            return False
+        if match:
+            version = int(match.group(1))
+            if java_major_version > version:
+                msg = "Java 1.%d+ required" % java_major_version
+                return False
 
     return True
 


### PR DESCRIPTION
Hello,

When the default environment and the frontend servers changed to Debian 10, the new default Java version has break the g5k script responsible for init the Hadoop instance (in specif the util.py script). It happens because the regex applied in function check_java_version does not match the output of java --version ('openjdk 11.0.7') and calling match.group(1) results in a exception, as shown below:

```
  Traceback (most recent call last):
     ...
     File "build/bdist.linux-x86_64/egg/hadoop_g5k/cluster.py", line 168, in bootstrap
     File "build/bdist.linux-x86_64/egg/hadoop_g5k/util/util.py", line 74, in check_java_version
   AttributeError: 'NoneType' object has no attribute 'group'
```

A simple workaround is to change the hadoop_g5k/util/util.py in order to make the check_java_version function (line 67) return true in all cases OR testing if the return of re.match() is defined (this is what is done in this pull request). This will work just fine, as Hadoop works well with openjdk 11.0.7 that is used in the default env on Grid'5000.
